### PR TITLE
디테일 페이지 피드백 반영

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Pretendard", sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/src/pages/detail-page/index.tsx
+++ b/src/pages/detail-page/index.tsx
@@ -299,7 +299,7 @@ const PhoneNumberText = tw.div`
 `;
 
 const InstagramLink = tw.a`
-  font-14-r text-blue
+  font-14-r text-red
 `;
 
 const Divider = tw.div`

--- a/src/pages/detail-page/index.tsx
+++ b/src/pages/detail-page/index.tsx
@@ -217,7 +217,7 @@ const Wrapper = tw.div`
 `;
 
 const Container = tw.div`
-  flex flex-col gap-16 w-390
+  flex flex-col gap-20 w-390
 `;
 
 const Header = tw.div`
@@ -356,7 +356,7 @@ const RecommendText = tw.div`
 `;
 
 const QuoteStartImage = tw.img`
-  w-16 h-16
+  w-30 h-22
 `;
 
 const QuateEndBox = tw.div`
@@ -364,7 +364,7 @@ const QuateEndBox = tw.div`
 `;
 
 const QuoteEndImage = tw.img`
-  w-16 h-16
+  w-30 h-22
 `;
 
 const LocationTitle = tw.div`

--- a/src/pages/main-page/LocationPathBox.tsx
+++ b/src/pages/main-page/LocationPathBox.tsx
@@ -21,6 +21,7 @@ const Wrapper = tw.div`
   w-110 h-50
   cursor-pointer
   hover:(bg-orange text-white)
+  active:(bg-orange text-white)
 `;
 
 const LocationPathText = tw.div`

--- a/src/pages/main-page/index.tsx
+++ b/src/pages/main-page/index.tsx
@@ -91,11 +91,11 @@ const LocationViewingWrapper = tw.div`
 `;
 
 const LocationViewingText = tw.div`
-  flex font-18-sb 
+  flex font-18-sb font-black
 `;
 
 const LocationPathContainer = tw.div`
-  grid grid-cols-3 gap-4
+  grid grid-cols-3 gap-10
   w-350
 `;
 

--- a/src/pages/main-page/index.tsx
+++ b/src/pages/main-page/index.tsx
@@ -91,7 +91,7 @@ const LocationViewingWrapper = tw.div`
 `;
 
 const LocationViewingText = tw.div`
-  flex font-18-sb font-black
+  flex font-18-sb text-black
 `;
 
 const LocationPathContainer = tw.div`


### PR DESCRIPTION
폰트가 애플고딕네오로 적용되어 있던데 프리텐다드로 작업 부탁드립니다.
https://cactus.tistory.com/306 (다운로드 페이지)
두 폰트가 흡사해보이지만 자간이나 획의 굵기가 달라서 디자인적으로 차이가 있습니다.
헤더 아래 간격 16>20px 수정 부탁드립니다.
-인스타그램 주소 이 부분은 제가 색상 지정을 하긴 했는데, 링크 나타낼 때 기본적으로 보여지는 컬러값이 있나요?
있다면 기본값으로 설정하고, 제가 지정한 컬러값은 삭제해도 될 것 같습니다.
(제가 정한 컬러값 #FF5454 / 현재 작업된 컬러값 #3476E6)
-추천사 부분 “ quotes-start,end 이미지가 16*16으로 작게 들어가 있습니다. 원본 사이즈로 보여주세요 ㅜㅜ

해당 피드백 완료